### PR TITLE
Update deprecated Stan syntax

### DIFF
--- a/inst/stan/BY_BM_single.stan
+++ b/inst/stan/BY_BM_single.stan
@@ -8,9 +8,9 @@ data {
   // observed treatment
   vector[N] A;
   // observed mediator
-  int<lower=0,upper=1> M[N];
+  array[N] int<lower=0,upper=1> M;
   // outcome
-  int<lower=0,upper=1> Y[N];
+  array[N] int<lower=0,upper=1> Y;
   // mean of regression priors
   vector[P + 2] location_y;
   vector[P + 1] location_m;

--- a/inst/stan/BY_BM_single_sens.stan
+++ b/inst/stan/BY_BM_single_sens.stan
@@ -8,9 +8,9 @@ data {
   // observed treatment 
   vector[N] A;
   // observed mediator
-  int<lower=0,upper=1> M[N];
+  array[N] int<lower=0,upper=1> M;
   // outcome
-  int<lower=0,upper=1> Y[N];
+  array[N] int<lower=0,upper=1> Y;
   // mean of regression priors 
   vector[P + 2] location_y; 
   vector[P + 1] location_m; 

--- a/inst/stan/BY_NM_single.stan
+++ b/inst/stan/BY_NM_single.stan
@@ -10,7 +10,7 @@ data {
   // observed mediator
   vector [N] M;
   // outcome
-  int<lower=0,upper=1> Y[N];
+  array[N] int<lower=0,upper=1> Y;
   // mean of regression priors
   vector[P + 2] location_y;
   vector[P + 1] location_m;

--- a/inst/stan/BY_NM_single_sens.stan
+++ b/inst/stan/BY_NM_single_sens.stan
@@ -10,7 +10,7 @@ data {
   // observed mediator 
   vector [N] M; 
   // outcome 
-  int<lower=0,upper=1> Y[N]; 
+  array[N] int<lower=0,upper=1> Y;
   // mean of regression priors 
   vector[P + 2] location_y; 
   vector[P + 1] location_m; 

--- a/inst/stan/NY_BM_single.stan
+++ b/inst/stan/NY_BM_single.stan
@@ -8,7 +8,7 @@ data {
   // observed treatment
   vector[N] A;
   // observed mediator
-  int<lower=0,upper=1> M[N];
+  array[N] int<lower=0,upper=1> M;
   // outcome
   vector [N] Y;
   // mean of regression priors

--- a/inst/stan/NY_BM_single_sens.stan
+++ b/inst/stan/NY_BM_single_sens.stan
@@ -8,7 +8,7 @@ data {
   // observed treatment 
   vector[N] A;
   // observed mediator
-  int<lower=0,upper=1> M[N];
+  array[N] int<lower=0,upper=1> M;
   // outcome
   vector [N] Y;
   // mean of regression priors 


### PR DESCRIPTION
This PR updates the Stan syntax in your package to use the new `array` syntax, otherwise your package will break with the next version of `rstan`. Thanks!